### PR TITLE
Add inertia_matrix property to six_x_six schema

### DIFF
--- a/windIO/turbine/IEAontology_schema.yaml
+++ b/windIO/turbine/IEAontology_schema.yaml
@@ -3555,6 +3555,22 @@ definitions:
                                 minItems: 21
                                 maxItems: 21
                                 uniqueItems: false
+                inertia_matrix:
+                    type: object
+                    required:
+                        - grid
+                        - values
+                    properties:
+                        grid:
+                            $ref: "#/definitions/distributed_data/grid_nd"
+                        values:
+                            type: array
+                            items:
+                                type: array
+                                description: Inertia matrix 6x6, only upper diagonal reported line by line (21 elements), specified at each grid point
+                                minItems: 21
+                                maxItems: 21
+                                uniqueItems: false
     filter:
         type: object
         description: Linear filter, could be a LPF, HPF, NF, INF, or user_defined


### PR DESCRIPTION
<!--
IMPORTANT NOTES

Is this pull request ready to be merged?
- Do the existing tests pass and new tests added for new code?
- Is all development in a state where you are proud to share it with others and
  willing to ask other people to take the time to review it?
- Is it documented in such a way that a review can reasonably understand what you've
  done and why you've done it? Can other users understand how to use your changes?
If not but opening the pull request will facilitate development, make it a "draft" pull request.

This form is written in GitHub's Markdown format. For a reference on this type
of syntax, see GitHub's documentation:
https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax

This template contains guidance for your submission within the < ! - -, - - > blocks.
These are comments in HTML syntax and will not appear in the submission.
Be sure to use the "Preview" feature on GitHub to ensure your submission is formatted as intended.

When including code snippets, please paste the text itself and wrap the code block with
ticks (see the other character on the tilde ~ key in a US keyboard) to format it as code.
For example, Python code should be wrapped in ticks like this:
```python
def a_func():
    return 1

a = 1
b = a_func()
print(a + b)
```
This is preferred over screen shots since it is searchable and others can copy/paste
the text to run it.

YAML is also supported:
```yaml
a_key: a_value
list_key:
- item1
- item2
```
-->


# Add `inertia_matrix` to `six_x_six` structure
<!--
Be sure to title your pull request so that readers can scan through the list of PR's and understand
what this one involves. It should be a few well selected words to get the point across. If you have
a hard time choosing a brief title, consider splitting the pull request into multiple pull requests.
Keep in mind that the title will be automatically included in the release notes.
-->
This PR adds the `inertia_matrix` field to the `six_x_six` schema as a duplicate of the `stiffness_matrix` field.

## Impacted areas of the software
<!--
List other areas that should be impacted by this pull request.
This helps to determine the verification tests.
-->
This change impacts `IEAontology_schema.yaml` and requires that the `inertia_matrix` field be part of the structure.

## Additional supporting information
<!--
Add any other context about the code contribution here.
-->

The `inertia_matrix` properties are the same as `stiffness_matrix` in the `six_x_six` structure. However, this field was not part of the schema, so when using the schema to generate C++ data structures, this field was missing.

## Test results, if applicable
<!--
Add the results from unit tests and regression tests here along with justification for any failing test cases.
-->
Test results are unaffected.

<!--
__ For maintainer use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] setup.py
- [ ] Verify docs builds correctly
- [ ] Create a tag in the IEAWindTask37/windIO repository
-->