### PR TITLE
Draft: Switch to ruamel.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     'jsonschema',
-    'pyyaml',
+    'ruamel.yaml',
     'xarray',       # TODO: this is used to load netcdf files through the validation function XrResourceLoader
     "netcdf4",
 ]

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -1,0 +1,149 @@
+import numpy as np
+from io import StringIO
+from pathlib import Path
+
+import windIO
+import windIO.yaml
+
+
+def assert_equal_dicts(d1, d2):
+    np.testing.assert_equal(type(d1), type(d2))
+    for key, val in d1.items():
+        if isinstance(val, dict):
+            assert_equal_dicts(val, d2[key])
+        elif isinstance(val, list):
+            assert_equal_lists(val, d2[key])
+        np.testing.assert_equal(type(val), type(d2[key]))
+        np.testing.assert_equal(val, d2[key])
+
+
+def assert_equal_lists(l1, l2):
+    np.testing.assert_equal(type(l1), type(l2))
+    np.testing.assert_equal(len(l1), len(l2))
+    for val1, val2 in zip(l1, l2):
+        if isinstance(val1, dict):
+            assert_equal_dicts(val1, val2)
+        elif isinstance(val1, list):
+            assert_equal_lists(val1, val2)
+        np.testing.assert_equal(type(val1), type(val2))
+        np.testing.assert_equal(val1, val2)
+
+
+def test_write_list_flow_style():
+    data = {
+        "a": [1, 2, 3],
+        "b": [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]],
+        "c": [1, "XY"],
+        "d": ["1", "2", "3"],
+        "e": [{"a": [1, 2], "b": [[[1, 2, 3], [4, 5, 6]], [[7, 8, 9], [10, 11, 12]]]}],
+    }
+
+    def get_yaml_str(data, flow_style=False):
+        out = StringIO()
+        yml_obj = windIO.YAML(typ="safe")
+        yml_obj.default_flow_style = flow_style
+        yml_obj.dump(data, out)
+        return out.getvalue()
+
+    # WithOUT flow style
+    out1 = StringIO()
+    windIO.yaml.get_YAML(n_list_flow_style=0).dump(data, out1)
+    str_data1 = out1.getvalue()
+    assert str_data1 == get_yaml_str(data)
+
+    # With flow-style for 1D numeric array
+    out1 = StringIO()
+    windIO.yaml.get_YAML(n_list_flow_style=1).dump(data, out1)
+    str_data1 = out1.getvalue()
+    for line in str_data1.split("\n"):
+        if "[" in line:
+            assert line.count("[") == 1 and line.count("]") == 1
+
+    # With flow-style for 2D numeric array
+    out1 = StringIO()
+    windIO.yaml.get_YAML(n_list_flow_style=2).dump(data, out1)
+    str_data1 = out1.getvalue()
+    for line in str_data1.split("\n"):
+        if "[" in line:
+            if line.count("[") > 1:
+                assert line.count("[") == 3 and line.count("]") == 3
+            else:
+                assert line.count("[") == 1 and line.count("]") == 1
+
+    # With flow-style for 3D numeric array
+    out1 = StringIO()
+    windIO.yaml.get_YAML(n_list_flow_style=3).dump(data, out1)
+    str_data1 = out1.getvalue()
+    for line in str_data1.split("\n"):
+        if "[" in line:
+            if line.count("[") > 1:
+                assert line.count("[") == 7 and line.count("]") == 7
+            else:
+                assert line.count("[") == 1 and line.count("]") == 1
+
+
+def test_write_numpy():
+
+    # Data to test against
+    test_data = dict(
+        a=[0.1, 0.2],
+        b=40,
+        c=30.0,
+        d="test",
+        e=[[0.1, 0.2], [0.3, 0.4]],
+        f=dict(a=[0.1, 0.2], b=40, c=30.0, d="test", e=[[0.1, 0.2], [0.3, 0.4]]),
+        g=[5, [1.0, 3.0], "test"],
+    )
+
+    # Data containing numpy types
+    din = dict(
+        a=np.array([0.1, 0.2]),
+        b=np.int16(40),
+        c=np.float16(30.0),
+        d=np.str_("test"),
+        e=np.array([[0.1, 0.2], [0.3, 0.4]]),
+        f=dict(
+            a=np.array([0.1, 0.2]),
+            b=np.int16(40),
+            c=np.float16(30.0),
+            d=np.str_("test"),
+            e=np.array([[0.1, 0.2], [0.3, 0.4]]),
+        ),
+        g=[5, np.array([1.0, 3.0]), "test"],
+    )
+
+    # File StringIO "file" to write to
+    tfile = StringIO()
+
+    # Write data to "file"
+    windIO.yaml.get_YAML().dump(din, tfile)
+    # Reset file location
+    tfile.seek(0)
+
+    # Convert "file" to python data (using the "safe" loader do get a python dict)
+    dout = windIO.yaml.get_YAML("safe").load(tfile)
+
+    # Asserting that dicts are equal
+    assert_equal_dicts(test_data, dout)
+
+
+def test_include():
+    base_path = Path(windIO.plant_ex.__file__).parent
+    # Include YAML file
+    filename = base_path / "plant_energy_site/IEA37_case_study_1_2_energy_site.yaml"
+    # without include
+    with open(filename, "r") as f:
+        for i in range(4):
+            f.readline()
+        out
+    out = windIO.yaml.get_YAML(read_include=False).load(filename)
+
+    # Include netCFD file
+    windIO.yaml.get_YAML().load(
+        base_path / "plant_energy_resource/GriddedResource_nc.yaml"
+    )
+    raise NotImplementedError("Should be tested against a manually embedding")
+
+
+def test_numpy_read():
+    raise NotImplementedError("Test for reading numeric array into numpy")

--- a/windIO/__init__.py
+++ b/windIO/__init__.py
@@ -1,6 +1,6 @@
 
 from __future__ import annotations
-import yaml
+from ruamel.yaml import YAML
 import os
 import copy
 from pathlib import Path, PosixPath, WindowsPath
@@ -11,6 +11,7 @@ import xarray as xr
 from typing import Any
 
 ### API design
+import windIO.yaml
 import windIO.examples.plant
 import windIO.examples.turbine
 import windIO.schemas
@@ -20,71 +21,8 @@ import windIO.schemas.turbine       # in the calling code after only importing w
 plant_ex = windIO.examples.plant
 turbine_ex = windIO.examples.turbine
 schemas = windIO.schemas
+load_yaml = windIO.yaml.load_yaml
 ### API design
-
-
-class XrResourceLoader(yaml.SafeLoader):
-    """
-    This class is a custom loader for yaml files that also enables loading
-    NetCDF files. For pure YAML files, it behaves like the default yaml.SafeLoader.
-    For NetCDF files, it uses xarray to load the data and then converts it to a dictionary.
-    Software incorporating windIO generally will not need to use this class directly.
-    """
-    def __init__(self, stream):
-        self._root = os.path.split(stream.name)[0]
-        super().__init__(stream)
-
-    def include(self, node):
-        filename = os.path.join(self._root, self.construct_scalar(node))
-        ext = os.path.splitext(filename)[1].lower()
-        if ext in ['.yaml', '.yml']:
-            with open(filename, 'r') as f:
-                return yaml.load(f, XrResourceLoader)
-        elif ext in ['.nc']:
-            def fmt(v: Any) -> dict | list | str | float | int:
-                """
-                Formats a dictionary appropriately for yaml.load by converting Tuples to Lists.
-
-                Args:
-                    v (Any): Initially, a dictionary of inputs to format. Then, individual
-                        values within the dictionary.
-                """
-                if isinstance(v, dict):
-                    return {k: fmt(v) for k, v in v.items() if fmt(v) != {}}
-                elif isinstance(v, tuple):
-                    return list(v)
-                else:
-                    return v
-
-            def ds2yml(ds: xr.Dataset) -> dict:
-                """
-                Converts the input xr.Dataset to a format compatible with yaml.load.
-
-                Args:
-                    ds (xr.Dataset): NetCDF data loaded as a xr.Dataset
-                """
-                d = ds.to_dict()
-                return fmt({**{k: v['data'] for k, v in d['coords'].items()},
-                            **d['data_vars']})
-            return ds2yml(xr.open_dataset(filename))
-        else:
-            raise ValueError(f"Unsupported file extension: {ext}")
-XrResourceLoader.add_constructor('!include', XrResourceLoader.include)
-
-def load_yaml(filename: str, loader=XrResourceLoader) -> dict:
-    """
-    Opens ``filename`` and loads the content into a dictionary with the ``yaml.load``
-    function from pyyaml.
-
-    Args:
-        filename (str): Path to the local file to be loaded.
-        loader (yaml.SafeLoader, optional): Defaults to XrResourceLoader.
-
-    Returns:
-        dict: Dictionary representation of the YAML file given in ``filename``.
-    """
-    with open(filename) as fid:
-        return yaml.load(fid, loader)
 
 def enforce_no_additional_properties(schema):
     """Recursively set additionalProperties: false for all objects in the schema"""
@@ -131,7 +69,7 @@ def _add_local_schemas_to(resolver, schema_folder, base_uri, schema_ext_lst=['.j
                         if schema_path.suffix == '.json':
                             schema_doc = json.load(schema_file)
                         if schema_path.suffix in ['.yml', '.yaml']:
-                            schema_doc = yaml.safe_load(schema_file)
+                            schema_doc = load_yaml(schema_file)
 
                     key = urljoin(base_uri, str(rel_path))
                     resolver.store[key] = schema_doc

--- a/windIO/yaml.py
+++ b/windIO/yaml.py
@@ -1,0 +1,126 @@
+import os
+from typing import Any
+
+import numpy as np
+from ruamel.yaml import YAML
+import xarray as xr
+
+
+def get_YAML(
+    typ: str = "safe",
+    write_numpy: bool = True,
+    read_include: bool = True,
+    n_list_flow_style: int = 1,
+) -> YAML:
+    yaml_obj = YAML(typ=typ)
+    yaml_obj.default_flow_style = False
+    yaml_obj.width = 1e6
+    yaml_obj.indent(mapping=4, sequence=6, offset=3)
+    yaml_obj.allow_unicode = False
+
+    # Write nested list of numbers with flow-style
+    def list_rep(dumper, data):
+        try:
+            npdata = np.asanyarray(data)  # Convert to numpy
+            if np.isdtype(npdata.dtype, "numeric"):  # Test if data is numeric
+                if n_list_flow_style >= len(
+                    npdata.shape
+                ):  # Test if n_list_flow_style is larger or equal to array shape
+                    return dumper.represent_sequence(
+                        "tag:yaml.org,2002:seq", data, flow_style=True
+                    )
+        except ValueError:
+            pass
+        return dumper.represent_sequence(
+            "tag:yaml.org,2002:seq", data, flow_style=False
+        )
+
+    yaml_obj.Representer.add_representer(list, list_rep)
+
+    if write_numpy:
+        # Convert numpy types to build in data types
+        yaml_obj.Representer.add_multi_representer(
+            np.str_, lambda dumper, data: dumper.represent_str(str(data))
+        )
+        yaml_obj.Representer.add_multi_representer(
+            np.number,
+            lambda dumper, data: dumper.represent_float(float(data)),
+        )
+        yaml_obj.Representer.add_multi_representer(
+            np.integer, lambda dumper, data: dumper.represent_int(int(data))
+        )
+
+        # Convert numpy array to list
+        def ndarray_rep(dumper, data):
+            return list_rep(dumper, data.tolist())
+
+        yaml_obj.Representer.add_representer(np.ndarray, ndarray_rep)
+
+    if read_include:
+
+        def include(constructor, node):
+            filename = os.path.join(
+                os.path.dirname(constructor.loader.reader.stream.name), node.value
+            )
+            ext = os.path.splitext(filename)[1].lower()
+            if ext in [".yaml", ".yml"]:
+                return load_yaml(
+                    filename, get_YAML()
+                )  # TODO: Make `get_YAML()` dynamic to make it possible to update
+            elif ext in [".nc"]:
+
+                def fmt(v: Any) -> dict | list | str | float | int:
+                    """
+                    Formats a dictionary appropriately for yaml.load by converting Tuples to Lists.
+
+                    Args:
+                        v (Any): Initially, a dictionary of inputs to format. Then, individual
+                            values within the dictionary.
+                    """
+                    if isinstance(v, dict):
+                        return {k: fmt(v) for k, v in v.items() if fmt(v) != {}}
+                    elif isinstance(v, tuple):
+                        return list(v)
+                    else:
+                        return v
+
+                def ds2yml(ds: xr.Dataset) -> dict:
+                    """
+                    Converts the input xr.Dataset to a format compatible with yaml.load.
+
+                    Args:
+                        ds (xr.Dataset): NetCDF data loaded as a xr.Dataset
+                    """
+                    d = ds.to_dict()
+                    return fmt(
+                        {
+                            **{k: v["data"] for k, v in d["coords"].items()},
+                            **d["data_vars"],
+                        }
+                    )
+
+                return ds2yml(xr.open_dataset(filename))
+            else:
+                raise ValueError(f"Unsupported file extension: {ext}")
+
+        yaml_obj.constructor.add_constructor("!include", include)
+
+    return yaml_obj
+
+
+def load_yaml(filename: str, loader=None) -> dict:
+    """
+    Opens ``filename`` and loads the content into a dictionary with the ``yaml.load``
+    function from pyyaml.
+
+    Args:
+        filename (str): Path to the local file to be loaded.
+        loader (yaml.SafeLoader, optional): Defaults to XrResourceLoader.
+
+    Returns:
+        dict: Dictionary representation of the YAML file given in ``filename``.
+    """
+    if loader is None:
+        loader = get_YAML()
+    with open(filename, "r") as fid:
+        return loader.load(fid)


### PR DESCRIPTION
# Switch from `pyyaml` to `ruamel.yaml`
This pull request aims to switch from the current use of `pyyaml` to `ruamel.yaml` as the `pyyaml` by default will install the compiled c-parser, which in case of failing to do so will fail the whole installation. `ruamel.yaml` will only try to install it but revert back to to "pure python" implementation if it fails.

The following high level changes have been made:
-  Made a dedicated `yaml.py` file. (Collecting things in windIO related to YAML)
- Added a method for getting the new default YAML parser object (`windIO.get_YAML(...)`)
- Added parser support for writing data containing `numpy`
- Added parser support for reading `list` of numeric data into `numpy`
- Ported the support for `!include` constructer 

## Related issue
#47 

## Impacted areas of the software
Switched the YAML parser from `pyyaml` to `ruamel.yaml`. 
