### PR TITLE
Numpy 1.X compatibility for YAML parser

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,3 +38,31 @@ jobs:
         working-directory: ${{runner.workspace}}/windIO/
         run: |
           pytest test
+
+  numpy1pX:
+    name: Test for Numpy 1.X
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        shell: bash -l {0}
+
+    steps:
+      - name: checkout repository
+        uses: actions/checkout@v2
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.10
+
+      - name: Install dependencies
+        working-directory: ${{runner.workspace}}/windIO/
+        run: |
+          python -m pip install --upgrade pip
+          pip install ".[test]" numpy==1.26
+
+      - name: Run tests
+        working-directory: ${{runner.workspace}}/windIO/
+        run: |
+          pytest test

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This software is a version 1.0
 
 ## Documentation and citation
 
-The online documentation can be accessed here <https://ieawindsystems.github.io/windio>
+The online documentation can be accessed here <https://ieawindsystems.github.io/windIO/>
 
 If you use this model in your research or publications, please cite this [IEA technical report](https://doi.org/10.2172/1868328):
 

--- a/windIO/yaml.py
+++ b/windIO/yaml.py
@@ -72,7 +72,7 @@ def get_YAML(
     def list_rep(dumper, data):
         try:
             npdata = np.asanyarray(data)  # Convert to numpy
-            if np.isdtype(npdata.dtype, "numeric"):  # Test if data is numeric
+            if np.issubdtype(npdata.dtype, np.number):  # Test if data is numeric
                 if n_list_flow_style >= len(
                     npdata.shape
                 ):  # Test if n_list_flow_style is larger or equal to array shape
@@ -111,7 +111,7 @@ def get_YAML(
         try:
             if read_numpy:
                 npdata = np.asarray(default_data)
-                if np.isdtype(npdata.dtype, "numeric"):
+                if np.issubdtype(npdata.dtype, np.number):
                     return npdata
             raise ValueError
         except ValueError:


### PR DESCRIPTION
# Numpy 1.X compatibility for YAML parser

With the merge of #107 the code had introduced a numpy feature that is only available in numpy 2.X and it broke other codes which was not compatible with numpy 2 yet. This pull request fixes this issue and insures that it is compatible with both numpy 1.X and 2.X.

It also adds a test for numpy 1.X to the CI pipeline.

## Related issue
None

## Impacted areas of the software
A bugfix and extension of the tests

## Additional supporting information
None

## Test results, if applicable
None