### PR TITLE
Improving validation error

### DIFF
--- a/test/test_schema.py
+++ b/test/test_schema.py
@@ -1,62 +1,55 @@
-import jsonschema.exceptions
-import pytest 
+import pytest
 import windIO
-import jsonschema 
+import windIO.schemas
+import jsonschema.exceptions
+
 
 def test_windIOMetaSchema():
-    windIO.schemas.windIOMetaSchema.check_schema(dict(
-        title="Dummy test schema",
-        properties=dict(
-            var1=dict(type="number"),
-            var2=dict(type="integer"),
-            var3=dict(type="string"),
-            var_with_units=dict(
-                type="number",
-                units="m*s"
+    windIO.schemas.windIOMetaSchema.check_schema(
+        dict(
+            title="Dummy test schema",
+            properties=dict(
+                var1=dict(type="number"),
+                var2=dict(type="integer"),
+                var3=dict(type="string"),
+                var_with_units=dict(type="number", units="m*s"),
+                var_none_with_units=dict(type="number", units="dimensionless"),
             ),
-            var_none_with_units=dict(
-                type="number",
-                units="dimensionless"
-            )
-        ),
-        definitions=dict(
-            definitions_can_contain_any_keyword=5
+            definitions=dict(definitions_can_contain_any_keyword=5),
         )
-    ))
+    )
 
-    with pytest.raises(jsonschema.exceptions.SchemaError, match="Additional properties are not allowed"):
-        windIO.schemas.windIOMetaSchema.check_schema(dict(
-        title="Failed keyword",
-        not_a_key_word = 5
-    ))
-        
-    with pytest.raises(jsonschema.exceptions.SchemaError, match="5 is not of type"):
-        windIO.schemas.windIOMetaSchema.check_schema(dict(
-        title="Units should be a string",
-        properties=dict(
-            var_with_units=dict(
-                type="number",
-                units=5
-            ))
-    ))
-        
-    with pytest.raises(jsonschema.exceptions.SchemaError, match="'not_a_units' is not a"):
-        windIO.schemas.windIOMetaSchema.check_schema(dict(
-        title="Units should have a number format",
-        properties=dict(
-            var_with_units=dict(
-                type="number",
-                units="not_a_units"
-            ))
-    ))
-        
-    with pytest.raises(jsonschema.exceptions.SchemaError, match="'None' is not a"):
-        windIO.schemas.windIOMetaSchema.check_schema(dict(
-        title="Units should only be `none`",
-        properties=dict(
-            var_with_units=dict(
-                type="number",
-                units="None"
-            ))
-    ))
-        
+    with pytest.raises(
+        jsonschema.exceptions.ValidationError, match="Additional properties are not allowed"
+    ):
+        windIO.schemas.windIOMetaSchema.check_schema(
+            dict(title="Failed keyword", not_a_key_word=5)
+        )
+
+    with pytest.raises(jsonschema.exceptions.ValidationError, match="5 is not of type"):
+        windIO.schemas.windIOMetaSchema.check_schema(
+            dict(
+                title="Units should be a string",
+                properties=dict(var_with_units=dict(type="number", units=5)),
+            )
+        )
+
+    with pytest.raises(
+        jsonschema.exceptions.ValidationError, match="'not_a_units' is not a"
+    ):
+        windIO.schemas.windIOMetaSchema.check_schema(
+            dict(
+                title="Units should have a number format",
+                properties=dict(
+                    var_with_units=dict(type="number", units="not_a_units")
+                ),
+            )
+        )
+
+    with pytest.raises(jsonschema.exceptions.ValidationError, match="'None' is not a"):
+        windIO.schemas.windIOMetaSchema.check_schema(
+            dict(
+                title="Units should only be `none`",
+                properties=dict(var_with_units=dict(type="number", units="None")),
+            )
+        )

--- a/test/validation_test.py
+++ b/test/validation_test.py
@@ -1,97 +1,131 @@
+from pathlib import Path
+
+import jsonschema.exceptions
+import pytest
 
 import windIO
-from pathlib import Path
+
+
+def test_validate_raise():
+    # Test the validation error message that is raised and that it provides a useful inside into
+    turbine_reference_path = Path(windIO.turbine_ex.__file__).parent
+
+    IEA_15MW_turb_mod = windIO.load_yaml(turbine_reference_path / "IEA-15-240-RWT.yaml")
+
+    # Not a defined entry with strict
+    IEA_15MW_turb_mod["components"]["blade"]["reference_axis"]["I_should_not_be_here"] = "Sorry"
+    IEA_15MW_turb_mod["components"]["blade"]["outer_shape"]["airfoils"][0]["name"] = 5
+    IEA_15MW_turb_mod["materials"][0].pop("name")
+
+    with pytest.raises(jsonschema.exceptions.ValidationError, match="The validation found 3 error"):
+        windIO.validate(IEA_15MW_turb_mod, "turbine/turbine_schema")
 
 
 def test_validation_IEA_case_studies_1_2():
 
     plant_reference_path = Path(windIO.plant_ex.__file__).parent
     windIO.validate(
-        input=plant_reference_path / 'wind_energy_system/IEA37_case_study_1_2_wind_energy_system.yaml',
-        schema_type="plant/wind_energy_system"
+        input=plant_reference_path
+        / "wind_energy_system/IEA37_case_study_1_2_wind_energy_system.yaml",
+        schema_type="plant/wind_energy_system",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_resource/IEA37_case_study_1_2_energy_resource.yaml',
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/IEA37_case_study_1_2_energy_resource.yaml",
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_site/IEA37_case_study_1_2_energy_site.yaml',
-        schema_type="plant/site"
+        input=plant_reference_path
+        / "plant_energy_site/IEA37_case_study_1_2_energy_site.yaml",
+        schema_type="plant/site",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_wind_farm/IEA37_case_study_1_2_wind_farm.yaml',
-        schema_type="plant/wind_farm"
+        input=plant_reference_path
+        / "plant_wind_farm/IEA37_case_study_1_2_wind_farm.yaml",
+        schema_type="plant/wind_farm",
     )
+
 
 def test_validation_IEA_case_studies_3():
 
     plant_reference_path = Path(windIO.plant_ex.__file__).parent
 
     windIO.validate(
-        input=plant_reference_path / 'wind_energy_system/IEA37_case_study_3_wind_energy_system.yaml',
-        schema_type="plant/wind_energy_system"
+        input=plant_reference_path
+        / "wind_energy_system/IEA37_case_study_3_wind_energy_system.yaml",
+        schema_type="plant/wind_energy_system",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_resource/IEA37_case_study_3_energy_resource.yaml',
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/IEA37_case_study_3_energy_resource.yaml",
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_site/IEA37_case_study_3_energy_site.yaml',
-        schema_type="plant/site"
+        input=plant_reference_path
+        / "plant_energy_site/IEA37_case_study_3_energy_site.yaml",
+        schema_type="plant/site",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_wind_farm/IEA37_case_study_3_wind_farm.yaml',
-        schema_type="plant/wind_farm"
+        input=plant_reference_path
+        / "plant_wind_farm/IEA37_case_study_3_wind_farm.yaml",
+        schema_type="plant/wind_farm",
     )
+
 
 def test_validation_IEA_case_studies_4():
 
     plant_reference_path = Path(windIO.plant_ex.__file__).parent
 
     windIO.validate(
-        input=plant_reference_path / 'wind_energy_system/IEA37_case_study_4_wind_energy_system.yaml',
-        schema_type="plant/wind_energy_system"
+        input=plant_reference_path
+        / "wind_energy_system/IEA37_case_study_4_wind_energy_system.yaml",
+        schema_type="plant/wind_energy_system",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_resource/IEA37_case_study_4_energy_resource.yaml',
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/IEA37_case_study_4_energy_resource.yaml",
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_site/IEA37_case_study_4_energy_site.yaml',
-        schema_type="plant/site"
+        input=plant_reference_path
+        / "plant_energy_site/IEA37_case_study_4_energy_site.yaml",
+        schema_type="plant/site",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_wind_farm/IEA37_case_study_4_wind_farm.yaml',
-        schema_type="plant/wind_farm"
+        input=plant_reference_path
+        / "plant_wind_farm/IEA37_case_study_4_wind_farm.yaml",
+        schema_type="plant/wind_farm",
     )
+
 
 def test_validation_IEA_turbines():
 
     plant_reference_path = Path(windIO.plant_ex.__file__).parent
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_turbine/IEA37_3.35MW_turbine.yaml',
-        schema_type="plant/turbine"
+        input=plant_reference_path / "plant_energy_turbine/IEA37_3.35MW_turbine.yaml",
+        schema_type="plant/turbine",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_turbine/IEA37_10MW_turbine.yaml',
-        schema_type="plant/turbine"
+        input=plant_reference_path / "plant_energy_turbine/IEA37_10MW_turbine.yaml",
+        schema_type="plant/turbine",
     )
 
     windIO.validate(
-        input=plant_reference_path / 'plant_energy_turbine/IEA37_15MW_turbine.yaml',
-        schema_type="plant/turbine"
+        input=plant_reference_path / "plant_energy_turbine/IEA37_15MW_turbine.yaml",
+        schema_type="plant/turbine",
     )
+
 
 def test_validation_energy_resources():
 
@@ -100,46 +134,49 @@ def test_validation_energy_resources():
     # Uniform Resource
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/UniformResource.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/UniformResource_nc.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
 
     # UniformWeibull Resource
     windIO.validate(
-        input=plant_reference_path / "plant_energy_resource/UniformWeibullResource.yaml",
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/UniformWeibullResource.yaml",
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
-        input=plant_reference_path / "plant_energy_resource/UniformWeibullResource_nc.yaml",
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/UniformWeibullResource_nc.yaml",
+        schema_type="plant/energy_resource",
     )
 
     # WT distributed Resource
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/WTResource.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/WTResource_nc.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
 
     # Gridded Resource
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/GriddedResource.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/GriddedResource_nc.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
+
 
 def test_validation_timeseries():
 
@@ -147,15 +184,20 @@ def test_validation_timeseries():
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/timeseries.yaml",
-        schema_type="plant/energy_resource"
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
-        input=plant_reference_path / "plant_energy_resource/timeseries_with_netcdf.yaml",
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/timeseries_with_netcdf.yaml",
+        schema_type="plant/energy_resource",
     )
 
     windIO.validate(
-        input=plant_reference_path / "plant_energy_resource/timeseries_vertical_variation.yaml",
-        schema_type="plant/energy_resource"
+        input=plant_reference_path
+        / "plant_energy_resource/timeseries_vertical_variation.yaml",
+        schema_type="plant/energy_resource",
     )
+
+if __name__ == "__main__":
+    test_validate_raise()

--- a/windIO/schemas/__init__.py
+++ b/windIO/schemas/__init__.py
@@ -4,32 +4,36 @@ The windIO Meta-schema extends the JSON-Schema Draft 7: https://json-schema.org/
 
 It extends the Draft 7 meta-schema in the following ways:
 
-    - Sets `additionalProperties = False`. 
+    - Sets `additionalProperties = False`.
       It means that the schema do not allow entries that are not defined by the schema to avoid and catch typos.
-    - Adds a `units` field. 
-      It enables the possibility to add units for ex. `number` entries. The `units` is added with the `format=units` 
+    - Adds a `units` field.
+      It enables the possibility to add units for ex. `number` entries. The `units` is added with the `format=units`
       which is not defined in the standard format entries: https://json-schema.org/draft/2020-12/draft-bhutton-json-schema-validation-00#rfc.section.7.3
-    - Adding an `optional` entry. 
-      It is a "copy" of the `required` entry which allows to just specify the entries 
+    - Adding an `optional` entry.
+      It is a "copy" of the `required` entry which allows to just specify the entries
       that are optional - which is the default if not in the `required` list.
 
 Besides the extension of the Draft 7 Meta-Schema the Python `jsonschema.validator` is also extended:
 
     - Validation of the `units` format.
-      As stated above, the `"format": "units"` is a non-standard format for JSON-schema. 
+      As stated above, the `"format": "units"` is a non-standard format for JSON-schema.
       Therefore the validator is extended with a format validation which is done with the `pint` module:https://pint.readthedocs.io/en/stable/
-      It is a light weight pure-python module which enables working with units in Python. 
-      The validation is simply done my checking if `pint` can parse the units instance. 
+      It is a light weight pure-python module which enables working with units in Python.
+      The validation is simply done my checking if `pint` can parse the units instance.
       The format of the units field is therefore consistent across the schema.
       The default units defined can be seen here: https://github.com/hgrecco/pint/blob/master/pint/default_en.txt
       `pint` is not a required dependency as an average user as they are not expected to validate the windIO schemas them self (but only instances of the schema).
 """
+
 import jsonschema
 from pathlib import Path
 import jsonschema.validators
+import jsonschema.exceptions
+
 try:
     # Checks if `pint` is installed - if not the `units` format is not validated for windIO meta schemas (not relevant for the average user)
     import pint
+
     has_pint = True
 except ImportError:
     has_pint = False
@@ -40,24 +44,80 @@ schemaPath = Path(__file__).parent
 windIOMetaSchema = jsonschema.validators.extend(jsonschema.Draft7Validator)
 
 # Updating the Meta-Schema
-windIOMetaSchema.META_SCHEMA["title"] = "windIO Meta Schema - an extension of the draft 7 meta schema"
+windIOMetaSchema.META_SCHEMA["title"] = (
+    "windIO Meta Schema - an extension of the draft 7 meta schema"
+)
 windIOMetaSchema.META_SCHEMA["$id"] = "windIO/schema/meta-schema"
 windIOMetaSchema.META_SCHEMA["additionalProperties"] = False
 windIOMetaSchema.META_SCHEMA["properties"]["definitions"]["additionalProperties"] = True
-windIOMetaSchema.META_SCHEMA["properties"]["units"] = dict(type="string", format="units")
-windIOMetaSchema.META_SCHEMA["properties"]["optional"] = windIOMetaSchema.META_SCHEMA["properties"]["required"] # Allow optional
+windIOMetaSchema.META_SCHEMA["properties"]["units"] = dict(
+    type="string", format="units"
+)
+windIOMetaSchema.META_SCHEMA["properties"]["optional"] = windIOMetaSchema.META_SCHEMA[
+    "properties"
+][
+    "required"
+]  # Allow optional
+
+
+def schema_validation_error_formatter(errs: jsonschema.Draft7Validator.iter_errors, schema_id: str):
+    """Formatting validation errors from `.iter_errors` of a jsonschema.validator
+
+    Parameters
+    ----------
+    errs : jsonschema.Draft7Validator.iter_errors
+        iterator with the errors from the validation
+    schema_id : str
+        Name or ID for the schema used for the validation
+
+    Raises
+    ------
+    jsonschema.exceptions.ValidationError
+        Raised if `errs` is not empty.
+    """    
+    err_message = ""
+    n_errs = 0
+    for err in errs:
+        n_errs += 1
+        _message = f'Error {n_errs}: Failed at instance path `{err.json_path}` with error message: "{err.message}"\n'
+        err_message += _message
+
+    if n_errs > 0:
+        err_message = (
+            f"Validation of schema instance failed for schema `{schema_id}`\nThe validation found {n_errs} error(s) which are further detailed below.\n\n"
+            + err_message
+        )
+        raise jsonschema.exceptions.ValidationError(err_message)
+
+
+def check_schema(cls, schema, format_checker=jsonschema.validators._UNSET):
+    """Modified version of the check_schema for the default Draft7 validator which prints errors using `windIO.schema.schema_validation_error_formatter`"""
+    Validator = jsonschema.validators.validator_for(cls.META_SCHEMA, default=cls)
+    if format_checker is jsonschema.validators._UNSET:
+        format_checker = Validator.FORMAT_CHECKER
+    validator = Validator(
+        schema=cls.META_SCHEMA,
+        format_checker=format_checker,
+    )
+    schema_validation_error_formatter(
+        validator.iter_errors(schema), validator.schema["$id"]
+    )
+
+
+windIOMetaSchema.check_schema = classmethod(check_schema)
 
 if has_pint:
     # Adding a "units" format validator
     # Adding a `pint.UnitRegistry` instance to the validator
     windIOMetaSchema.units_reg = pint.UnitRegistry()
     # Adding non-default units
-    windIOMetaSchema.units_reg.define('USD = currency') # Using USD as the currency 
-    # Get the validator format-checker 
+    windIOMetaSchema.units_reg.define("USD = currency")  # Using USD as the currency
+    # Get the validator format-checker
     format_checker = windIOMetaSchema.FORMAT_CHECKER
+
     # Adding the `units` format checker method: https://python-jsonschema.readthedocs.io/en/stable/api/#jsonschema.FormatChecker.checks
-    @format_checker.checks("units", pint.errors.UndefinedUnitError)
+    @format_checker.checks("units", Exception)
     def check_units(instance: object):
-        """units format validator. Tests if the `pint` unit-registry can parse the units format """
+        """units format validator. Tests if the `pint` unit-registry can parse the units format"""
         windIOMetaSchema.units_reg.parse_expression(instance)
         return True

--- a/windIO/validator.py
+++ b/windIO/validator.py
@@ -9,7 +9,7 @@ import jsonschema
 import jsonschema.validators
 
 from .yaml import load_yaml
-from .schemas import schemaPath
+from .schemas import schemaPath, schema_validation_error_formatter
 
 
 def retrieve_yaml(uri: str):
@@ -100,13 +100,4 @@ def _jsonschema_validate_modified(instance, schema, cls=None, *args, **kwargs):
 
     cls.check_schema(schema)
     validator = cls(schema, *args, **kwargs)
-    err_message = ""
-    n_errs = 0
-    for err in validator.iter_errors(instance):
-        n_errs += 1
-        _message = f"Error {n_errs}: Failed at instance path `{err.json_path}` with error message: \"{err.message}\"\n"
-        err_message += _message
-
-    if n_errs > 0:
-        err_message = f"Validation of schema instance failed for schema `{schema['$id']}`\nThe validation found {n_errs} error(s) which are further detailed below.\n\n"+err_message
-        raise jsonschema.exceptions.ValidationError(err_message)
+    schema_validation_error_formatter(validator.iter_errors(instance), schema['$id'])

--- a/windIO/validator.py
+++ b/windIO/validator.py
@@ -60,7 +60,7 @@ def validate(
         schema_type (str): Type of schema to be used for validation. This must map to one
             of the schema files available in the ``schemas/plant`` or ``schemas/turbine`` folders.
             Examples of valid schema types are 'plant/wind_energy_system' or
-            '`turbine/IEAontology_schema`'.
+            '`turbine/turbine_schema`'.
         restrictive (bool, optional): If True, the schema will be modified to enforce
             that no additional properties are allowed. Defaults to True.
 


### PR DESCRIPTION
# Improving validation error
This PR aims to improve/modify the default error message printed/raised when schema validation fails.

I find the default validation error message very long, and it often does not aid my understanding of what is failing during the validation. This is partly caused by the fact that the default error message printing the data instance that failed does not clearly point out what failed. (See *Additional supporting information* below for an example)

The following has been changed:

1. The `jsonschema.validate` method has been embedded and modified via the `windIO.validator._jsonschema_validate_modified`
This method only changes how the error is raised and rendered through the `schema_validation_error_formatter` method.
`_jsonschema_validate_modified` method replaces the `jsonschema.validate` at the end of `windIO.validate` method.
2. The `schema_validation_error_formatter` can take an error iterator from a `jsonschema.validator` as well as the schema ID, and render and raise the errors found during the validation.
Opposed to the default error message, this one shows all the errors (the default only writes one of them), and it will only print the *object path* where the error happened and the message for the cause of the failed validation. It will not print the dict instance at which it failed.

## Related issue
Not related to any issue
The current version requires #131 to be merged first

## Impacted areas of the software
It should only impact the case where the validation of a schema fails, by how the error message is printed.

## Additional supporting information

Below shows an example of how the error message is rendered with this PR and how it is rendered by default in `jsonschema.validate`.

### Loading a yaml turbine instance and adding errors
```python
from pathlib import Path
import jsonschema
import windIO
import windIO.schemas

# Loading IEA 15
turbine_reference_path = Path(windIO.turbine_ex.__file__).parent
IEA_15MW_turb_mod = windIO.load_yaml(turbine_reference_path / "IEA-15-240-RWT.yaml")

# Adding errors
# Not a defined entry with `additionalPropeties=False`
IEA_15MW_turb_mod["components"]["blade"]["reference_axis"]["I_should_not_be_here"] = "Sorry"
# Not the correct type
IEA_15MW_turb_mod["components"]["blade"]["outer_shape"]["airfoils"][0]["name"] = 5
# Not having a requried entry
IEA_15MW_turb_mod["materials"][0].pop("name")
```

### Validations with error (using this PR)
```python
windIO.validate(IEA_15MW_turb_mod, "turbine/turbine_schema")
```
Which prints (output from a notebook):
```stdout
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[2], [line 10](vscode-notebook-cell:?execution_count=2&line=10)
      [7](vscode-notebook-cell:?execution_count=2&line=7) IEA_15MW_turb_mod["components"]["blade"]["outer_shape"]["airfoils"][0]["name"] = 5
      [8](vscode-notebook-cell:?execution_count=2&line=8) IEA_15MW_turb_mod["materials"][0].pop("name")
---> [10](vscode-notebook-cell:?execution_count=2&line=10) windIO.validate(IEA_15MW_turb_mod, "turbine/turbine_schema")

File ~/Desktop/projects/windIO/windIO/validator.py:94, in validate(input, schema_type, restrictive)
     [91](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/windIO/validator.py:91) if restrictive:
     [92](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/windIO/validator.py:92)     schema = _enforce_no_additional_properties(schema)
---> [94](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/windIO/validator.py:94) jsonschema_validate_mod(data, schema, registry=registry)

File ~/Desktop/projects/windIO/windIO/validator.py:112, in jsonschema_validate_mod(instance, schema, cls, *args, **kwargs)
    [110](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/windIO/validator.py:110) if n_errs > 0:
    [111](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/windIO/validator.py:111)     err_message = f"Validation of schema instance failed for schema `{schema['$id']}`\nThe validation found {n_errs} error(s) which are further detailed below.\n\n"+err_message
--> [112](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/windIO/validator.py:112)     raise jsonschema.exceptions.ValidationError(err_message)

ValidationError: Validation of schema instance failed for schema `windIO/turbine/turbine_schema`
The validation found 3 error(s) which are further detailed below.

Error 1: Failed at instance path `$.components.blade.reference_axis` with error message: "Additional properties are not allowed ('I_should_not_be_here' was unexpected)"
Error 2: Failed at instance path `$.components.blade.outer_shape.airfoils[0].name` with error message: "5 is not of type 'string'"
Error 3: Failed at instance path `$.materials[0]` with error message: "'name' is a required property"
```

### Validations with error (using default `jsonschema.validate`)

```python
jsonschema.validate(IEA_15MW_turb_mod, windIO.load_yaml(windIO.schemas.schemaPath/"turbine/turbine_schema.yaml"))
```
Which prints (output from a notebook):
```stdout
---------------------------------------------------------------------------
ValidationError                           Traceback (most recent call last)
Cell In[4], [line 4](vscode-notebook-cell:?execution_count=4&line=4)
      [1](vscode-notebook-cell:?execution_count=4&line=1) import windIO.schemas
----> [4](vscode-notebook-cell:?execution_count=4&line=4) jsonschema.validate(IEA_15MW_turb_mod, windIO.load_yaml(windIO.schemas.schemaPath/"turbine/turbine_schema.yaml"))

File ~/Desktop/projects/windIO/.env/lib/python3.10/site-packages/jsonschema/validators.py:1332, in validate(instance, schema, cls, *args, **kwargs)
   [1330](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/.env/lib/python3.10/site-packages/jsonschema/validators.py:1330) error = exceptions.best_match(validator.iter_errors(instance))
   [1331](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/.env/lib/python3.10/site-packages/jsonschema/validators.py:1331) if error is not None:
-> [1332](https://file+.vscode-resource.vscode-cdn.net/home/kenloen/Desktop/projects/windIO/.vscode/~/Desktop/projects/windIO/.env/lib/python3.10/site-packages/jsonschema/validators.py:1332)     raise error

ValidationError: 'name' is a required property

Failed validating 'required' in schema['properties']['materials']['items']:
    {'type': 'object',
     'required': ['name', 'orth', 'rho', 'E', 'nu'],
     'properties': {'name': {'type': 'string',
                             'description': 'Name of the material'},
                    'description': {'type': 'string',
                                    'description': 'Optional string to '
                                                   'describe the origin of '
                                                   'the material, for '
                                                   'example referencing a '
                                                   'report or a paper'},
                    'source': {'type': 'string',
                               'description': 'Optional field describing '
                                              'where the data come from'},
                    'orth': {'type': 'integer',
                             'description': 'Flag specifying whether a '
                                            'material is isotropic (0) or '
                                            'orthotropic (1). This '
                                            'determines whether some of '
                                            'the fields below are '
                                            'specified as a float or an '
                                            'array of floats.'},
                    'rho': {'description': 'Density of the material. For '
                                           'composites, this is the '
                                           'density of the laminate once '
                                           'cured.',
                            'type': 'number',
                            'units': 'kg/m^3',
                            'minimum': 0,
                            'maximum': 20000},
                    'E': {'description': 'Stiffness modulus. For '
                                         'orthotropic materials, it '
                                         'consists of an array with E11, '
                                         'E22, and E33.',
                          'oneOf': [{'type': 'number',
                                     'units': 'Pa',
                                     'minimum': 0},
                                    {'type': 'array',
                                     'items': {'type': 'number',
                                               'units': 'Pa',
                                               'minItems': 3,
                                               'maxItems': 3,
                                               'uniqueItems': False,
                                               'minimum': 0}}]},
                    'G': {'description': 'Shear stiffness modulus. For '
                                         'orthotropic materials, it '
                                         'consists of an array with G12, '
                                         'G13, and G23.',
                          'oneOf': [{'type': 'number',
                                     'units': 'Pa',
                                     'minimum': 0},
                                    {'type': 'array',
                                     'items': {'type': 'number',
                                               'units': 'Pa',
                                               'minItems': 3,
                                               'maxItems': 3,
                                               'uniqueItems': False,
                                               'minimum': 0}}]},
                    'nu': {'description': 'Poisson ratio. For orthotropic '
                                          'materials, it consists of an '
                                          'array with nu12, nu13 and nu23. '
                                          'For isotropic materials, a '
                                          'minimum of -1 and a maximum of '
                                          '0.5 are imposed. No limits are '
                                          'imposed to anisotropic '
                                          'materials.',
                           'oneOf': [{'type': 'number',
                                      'units': 'dimensionless',
                                      'minimum': -1.0,
                                      'maximum': 0.5},
                                     {'type': 'array',
                                      'items': {'type': 'number',
                                                'units': 'dimensionless',
                                                'minItems': 3,
                                                'maxItems': 3,
                                                'uniqueItems': False}}]},
                    'alpha': {'description': 'Thermal coefficient of '
                                             'expansion. For orthotropic '
                                             'materials, it consists of an '
                                             'array with alpha11, alpha22, '
                                             'and alpha33.',
                              'oneOf': [{'type': 'number', 'units': '1/K'},
                                        {'type': 'array',
                                         'items': {'type': 'number',
                                                   'units': '1/K',
                                                   'minItems': 3,
                                                   'maxItems': 3,
                                                   'uniqueItems': False}}]},
                    'Xt': {'description': 'Ultimate tensile strength. For '
                                          'orthotropic materials, it '
                                          'consists of an array with Xt11, '
                                          'Xt22, and Xt33.',
                           'oneOf': [{'type': 'number',
                                      'units': 'Pa',
                                      'minimum': 0},
                                     {'type': 'array',
                                      'items': {'type': 'number',
                                                'units': 'Pa',
                                                'minItems': 3,
                                                'maxItems': 3,
                                                'uniqueItems': False,
                                                'minimum': 0}}]},
                    'Xc': {'description': 'Ultimate compressive strength. '
                                          'For orthotropic materials, it '
                                          'consists of an array with Xc11, '
                                          'Xc22, and Xc33. Values are '
                                          'defined positive.',
                           'oneOf': [{'type': 'number',
                                      'units': 'Pa',
                                      'minimum': 0},
                                     {'type': 'array',
                                      'items': {'type': 'number',
                                                'units': 'Pa',
                                                'minItems': 3,
                                                'maxItems': 3,
                                                'uniqueItems': False,
                                                'minimum': 0}}]},
                    'Xy': {'description': 'Ultimate yield strength for '
                                          'metals. For orthotropic '
                                          'materials, it consists of an '
                                          'array with the strength in '
                                          'directions 12, 13 and 23',
                           'oneOf': [{'type': 'number',
                                      'units': 'Pa',
                                      'minimum': 0},
                                     {'type': 'array',
                                      'items': {'type': 'number',
                                                'units': 'Pa',
                                                'minItems': 3,
                                                'maxItems': 3,
                                                'uniqueItems': False,
                                                'minimum': 0}}]},
                    'S': {'description': 'Ultimate shear strength. For '
                                         'orthotropic materials, it '
                                         'consists of an array with the '
                                         'strength in directions 12, 13 '
                                         'and 23. Values are defined '
                                         'positive.',
                          'oneOf': [{'type': 'number',
                                     'units': 'Pa',
                                     'minimum': 0},
                                    {'type': 'array',
                                     'items': {'type': 'number',
                                               'units': 'Pa',
                                               'minItems': 3,
                                               'maxItems': 3,
                                               'uniqueItems': False,
                                               'minimum': 0}}]},
                    'ply_t': {'type': 'number',
                              'description': 'Ply thickness of a composite '
                                             'material. The unit of '
                                             'measure is m. The actual '
                                             'laminate thickness is '
                                             'defined in the fields '
                                             ':code:`components`.',
                              'units': 'm',
                              'minimum': 0,
                              'maximum': 0.1},
                    'unit_cost': {'type': 'number',
                                  'description': 'Unit cost of the '
                                                 'material. For '
                                                 'composites, this is the '
                                                 'unit cost of the dry '
                                                 'fabric.',
                                  'units': 'USD/kg',
                                  'minimum': 0,
                                  'maximum': 1000},
                    'fvf': {'type': 'number',
                            'description': 'Fiber volume fraction of a '
                                           'composite material. The '
                                           'minimum values is 0 (only '
                                           'matrix), the maximum value is '
                                           '1 (only fibers).',
                            'units': 'dimensionless',
                            'minimum': 0,
                            'maximum': 1},
                    'fwf': {'type': 'number',
                            'description': 'Fiber weight fraction of a '
                                           'composite material. The '
                                           'minimum values is 0 (only '
                                           'matrix), the maximum value is '
                                           '1 (only fibers).',
                            'units': 'dimensionless',
                            'minimum': 0,
                            'maximum': 1},
                    'fiber_density': {'type': 'number',
                                      'description': 'Density of the '
                                                     'fibers of a '
                                                     'composite material. '
                                                     'Standard glass fiber '
                                                     'has a fiber density '
                                                     'of approximately '
                                                     '2600 kg/m3, while '
                                                     'standard carbon '
                                                     'fiber has a fiber '
                                                     'density of '
                                                     'approximately 1800 '
                                                     'kg/m3.',
                                      'units': 'kg/m^3',
                                      'minimum': 0,
                                      'maximum': 10000},
                    'area_density_dry': {'type': 'number',
                                         'description': 'Aerial density of '
                                                        'a fabric of a '
                                                        'composite '
                                                        'material.',
                                         'units': 'kg/m^2',
                                         'minimum': 0,
                                         'maximum': 10000},
                    'manufacturing_id': {'type': 'integer',
                                         'description': 'Flag to define '
                                                        'the manufacturing '
                                                        'process behind '
                                                        'the laminate, for '
                                                        'example 0 - '
                                                        'coating, 1 - '
                                                        'sandwich filler , '
                                                        '2 - shell skin, 3 '
                                                        '- shear webs, 4 - '
                                                        'spar caps, 5 - TE '
                                                        'reinf.',
                                         'units': 'dimensionless',
                                         'enum': [0, 1, 2, 3, 4, 5]},
                    'waste': {'type': 'number',
                              'description': 'Fraction of material that '
                                             'ends up wasted during '
                                             'manufacturing.',
                              'units': 'dimensionless',
                              'minimum': 0,
                              'maximum': 1},
                    'roll_mass': {'type': 'number',
                                  'description': 'Mass of a fabric roll.',
                                  'units': 'kg',
                                  'minimum': 0,
                                  'maximum': 10000},
                    'GIc': {'type': 'number',
                            'description': 'Mode 1 critical energy-release '
                                           'rate.',
                            'units': 'J/m^2'},
                    'GIIc': {'type': 'number',
                             'description': 'Mode 2 critical '
                                            'energy-release rate.',
                             'units': 'J/m^2'},
                    'alp0': {'type': 'number',
                             'description': 'Fracture angle under pure '
                                            'transverse compression.',
                             'units': 'deg'},
                    'A': {'description': 'Fatigue S/N curve fitting '
                                         'parameter S=A*N^(-1/m). An array '
                                         'can be defined as a function of '
                                         'R (for composites) or as a '
                                         'function of number of cycles N '
                                         '(for multi-segment S-N curves, '
                                         'such as for metals).',
                          'oneOf': [{'type': 'number',
                                     'units': 'dimensionless',
                                     'minimum': 0,
                                     'default': 0.0},
                                    {'type': 'array',
                                     'items': {'type': 'number',
                                               'units': 'dimensionless',
                                               'uniqueItems': False,
                                               'minimum': 0,
                                               'default': 0.0}}]},
                    'm': {'description': 'Fatigue S/N curve fitting '
                                         'parameter S=A*N^(-1/m). An array '
                                         'can be defined as a function of '
                                         'R (for composites) or as a '
                                         'function of number of cycles N '
                                         '(for multi-segment S-N curves, '
                                         'such as for metals).',
                          'oneOf': [{'type': 'number',
                                     'units': 'dimensionless',
                                     'minimum': 0,
                                     'default': 1.0},
                                    {'type': 'array',
                                     'items': {'type': 'number',
                                               'units': 'dimensionless',
                                               'uniqueItems': False,
                                               'minimum': 0,
                                               'maximum': 1000,
                                               'default': 1.0}}]},
                    'R': {'description': 'Fatigue stress ratio. An array '
                                         'can be defined to build '
                                         'Goodman-correction diagrams.',
                          'oneOf': [{'type': 'number',
                                     'units': 'dimensionless',
                                     'default': -1.0},
                                    {'type': 'array',
                                     'items': {'type': 'number',
                                               'units': 'dimensionless',
                                               'uniqueItems': False,
                                               'minimum': -100,
                                               'maximum': 100,
                                               'default': -1.0}}]},
                    'N': {'description': 'Number of cycles for fatigue '
                                         'failure. An array can be defined '
                                         'to support multi-segment S-N '
                                         'curves such as for metals.',
                          'oneOf': [{'type': 'integer',
                                     'units': 'dimensionless',
                                     'default': 1},
                                    {'type': 'array',
                                     'items': {'type': 'integer',
                                               'units': 'dimensionless',
                                               'uniqueItems': False,
                                               'minimum': 1,
                                               'maximum': 10000000000.0,
                                               'default': 1}}]}}}

On instance['materials'][0]:
    {'orth': 0,
     'rho': 1235.0,
     'E': 3440000000.0,
     'G': 1323000000.0,
     'nu': 0.3,
     'alpha': 0.0,
     'Xt': 74,
     'Xc': 87,
     'S': 21260000.0,
     'GIc': 303,
     'GIIc': 3446,
     'alp0': 53,
     'ply_t': 0.0005,
     'waste': 0.25,
     'unit_cost': 7.23,
     'manufacturing_id': 0}
```

### Comments
The above shows that the size of the error message is significantly reduced by the PR and all the errors shown. But the changes made by this PR do not include the context at which it failed, which sometimes is useful when debugging. It is therefore a tradeoff, but I do generally think that this way is more useful as a default.