### PR TITLE
add scripts from wisdem to add defaults from schema. skip this step o…

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,6 @@ The suggested method of incorporating windIO into your code is:
 
    # Other code here
 
-   windIO.validate(input="path/to/input.yaml", schema_type="plant/wind_energy_system <for example>")
-   windIO.load_yaml("path/to/input.yaml")
+   data = windIO.validate(input="path/to/input.yaml", schema_type="plant/wind_energy_system <for example>")
 
    # Conversion to your software's data structures here

--- a/test/plant/wind_farm_schema_unit_test.py
+++ b/test/plant/wind_farm_schema_unit_test.py
@@ -18,17 +18,17 @@ def test_wind_farm_input(subtests):
     """
     with subtests.test("with valid config"):
         config = SampleInputs().wind_farm
-        windIO.validate(config, "plant/wind_farm")
+        windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("remove optional electrical_substations"):
         config = SampleInputs().wind_farm
         del config["electrical_substations"]
-        windIO.validate(config, "plant/wind_farm")
+        windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("remove optional electrical_collection_array"):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]
-        windIO.validate(config, "plant/wind_farm")
+        windIO.validate(config, "plant/wind_farm", defaults = False)
 
 
 def test_wind_farm_inputs_turbines(subtests):
@@ -37,11 +37,11 @@ def test_wind_farm_inputs_turbines(subtests):
     """
     with subtests.test("missing turbines"):
         config = SampleInputs().wind_farm
-        windIO.validate(config, "plant/wind_farm")
+        windIO.validate(config, "plant/wind_farm", defaults = False)
 
         # turbines are optional
         del config["turbines"]
-        windIO.validate(config, "plant/wind_farm")
+        windIO.validate(config, "plant/wind_farm", defaults = False)
 
 
 def test_wind_farm_invalid_inputs_electrical_substations(subtests):
@@ -52,18 +52,18 @@ def test_wind_farm_invalid_inputs_electrical_substations(subtests):
         config = SampleInputs().wind_farm
         del config["electrical_substations"][0]["electrical_substation"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("missing electrical_substation coordinates"):
         config = SampleInputs().wind_farm
         del config["electrical_substations"][0]["electrical_substation"]["coordinates"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("remove optional electrical_substation capacity"):
         config = SampleInputs().wind_farm
         del config["electrical_substations"][0]["electrical_substation"]["capacity"]
-        windIO.validate(config, "plant/wind_farm") is None
+        windIO.validate(config, "plant/wind_farm", defaults = False) is None
 
 
 def test_wind_farm_invalid_inputs_electrical_collection_array(subtests):
@@ -74,37 +74,37 @@ def test_wind_farm_invalid_inputs_electrical_collection_array(subtests):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]["edges"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("missing electrical_collection_array cables"):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]["cables"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("missing electrical_collection_array cables cable_type"):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]["cables"]["cable_type"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("missing electrical_collection_array cables cross_section"):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]["cables"]["cross_section"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("missing electrical_collection_array cables capacity"):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]["cables"]["capacity"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
     with subtests.test("missing electrical_collection_array cables cost"):
         config = SampleInputs().wind_farm
         del config["electrical_collection_array"]["cables"]["cost"]
         with pytest.raises(ValidationError):
-            windIO.validate(config, "plant/wind_farm")
+            windIO.validate(config, "plant/wind_farm", defaults = False)
 
 
 def test_plant_valid_schema():

--- a/test/test_all_plant_examples.py
+++ b/test/test_all_plant_examples.py
@@ -41,7 +41,7 @@ def test_validate_all_example_files():
             
             # Use pytest subtests to continue even if one file fails
             try:
-                windIO.validate(input=file_path, schema_type=schema_type)
+                windIO.validate(input=file_path, schema_type=schema_type, defaults = False)
             except Exception as e:
                 pytest.fail(f"Validation failed for {file_path}: {str(e)}")
 

--- a/test/test_yaml.py
+++ b/test/test_yaml.py
@@ -223,7 +223,7 @@ def test_load_yaml():
     ), "`yaml_Path` should be a `pathlib.Path` instance"
     IEA_10_turb = windIO.load_yaml(yaml_pathlib_Path)
     windIO.validate(
-        IEA_10_turb, "plant/turbine"
+        IEA_10_turb, "plant/turbine", defaults = False,
     )  # Testing that the loaded schema is valid
 
     # Load from string instance
@@ -231,14 +231,14 @@ def test_load_yaml():
     assert isinstance(yaml_str, str), "`yaml_str` should be a `str` instance"
     IEA_10_turb = windIO.load_yaml(yaml_str)
     windIO.validate(
-        IEA_10_turb, "plant/turbine"
+        IEA_10_turb, "plant/turbine", defaults=False,
     )  # Testing that the loaded schema is valid
 
     # As a file-handle
     with open(yaml_pathlib_Path, "r") as file:
         IEA_10_turb = windIO.load_yaml(file)
         windIO.validate(
-            IEA_10_turb, "plant/turbine"
+            IEA_10_turb, "plant/turbine", defaults=False,
         )  # Testing that the loaded schema is valid
 
     # Fail if not a path-like argument

--- a/test/validation_test.py
+++ b/test/validation_test.py
@@ -18,7 +18,7 @@ def test_validate_raise():
     IEA_15MW_turb_mod["materials"][0].pop("name")
 
     with pytest.raises(jsonschema.exceptions.ValidationError, match="The validation found 3 error"):
-        windIO.validate(IEA_15MW_turb_mod, "turbine/turbine_schema")
+        windIO.validate(IEA_15MW_turb_mod, "turbine/turbine_schema", defaults = False)
 
 
 def test_validation_IEA_case_studies_1_2():
@@ -28,24 +28,28 @@ def test_validation_IEA_case_studies_1_2():
         input=plant_reference_path
         / "wind_energy_system/IEA37_case_study_1_2_wind_energy_system.yaml",
         schema_type="plant/wind_energy_system",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_resource/IEA37_case_study_1_2_energy_resource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_site/IEA37_case_study_1_2_energy_site.yaml",
         schema_type="plant/site",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_wind_farm/IEA37_case_study_1_2_wind_farm.yaml",
         schema_type="plant/wind_farm",
+        defaults=False,
     )
 
 
@@ -57,24 +61,28 @@ def test_validation_IEA_case_studies_3():
         input=plant_reference_path
         / "wind_energy_system/IEA37_case_study_3_wind_energy_system.yaml",
         schema_type="plant/wind_energy_system",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_resource/IEA37_case_study_3_energy_resource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_site/IEA37_case_study_3_energy_site.yaml",
         schema_type="plant/site",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_wind_farm/IEA37_case_study_3_wind_farm.yaml",
         schema_type="plant/wind_farm",
+        defaults=False,
     )
 
 
@@ -86,24 +94,28 @@ def test_validation_IEA_case_studies_4():
         input=plant_reference_path
         / "wind_energy_system/IEA37_case_study_4_wind_energy_system.yaml",
         schema_type="plant/wind_energy_system",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_resource/IEA37_case_study_4_energy_resource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_site/IEA37_case_study_4_energy_site.yaml",
         schema_type="plant/site",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_wind_farm/IEA37_case_study_4_wind_farm.yaml",
         schema_type="plant/wind_farm",
+        defaults=False,
     )
 
 
@@ -114,16 +126,19 @@ def test_validation_IEA_turbines():
     windIO.validate(
         input=plant_reference_path / "plant_energy_turbine/IEA37_3.35MW_turbine.yaml",
         schema_type="plant/turbine",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_turbine/IEA37_10MW_turbine.yaml",
         schema_type="plant/turbine",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_turbine/IEA37_15MW_turbine.yaml",
         schema_type="plant/turbine",
+        defaults=False,
     )
 
 
@@ -135,11 +150,13 @@ def test_validation_energy_resources():
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/UniformResource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/UniformResource_nc.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     # UniformWeibull Resource
@@ -147,34 +164,40 @@ def test_validation_energy_resources():
         input=plant_reference_path
         / "plant_energy_resource/UniformWeibullResource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_resource/UniformWeibullResource_nc.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     # WT distributed Resource
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/WTResource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/WTResource_nc.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     # Gridded Resource
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/GriddedResource.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/GriddedResource_nc.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
 
@@ -185,18 +208,21 @@ def test_validation_timeseries():
     windIO.validate(
         input=plant_reference_path / "plant_energy_resource/timeseries.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_resource/timeseries_with_netcdf.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
     windIO.validate(
         input=plant_reference_path
         / "plant_energy_resource/timeseries_vertical_variation.yaml",
         schema_type="plant/energy_resource",
+        defaults=False,
     )
 
 if __name__ == "__main__":

--- a/windIO/schemas/turbine/turbine_schema.yaml
+++ b/windIO/schemas/turbine/turbine_schema.yaml
@@ -3187,12 +3187,11 @@ properties:
     environment:
         type: object
         description: The field :code:`environment` includes the data characterizing air and water where the wind turbine operates.
-        required:
+        optional:
             - air_density
             - air_dyn_viscosity
             - air_speed_sound
             - shear_exp
-        optional:
             - gravity
             - weib_shape_parameter
             - water_density


### PR DESCRIPTION
Unless I am missing something, currently the validation step is not adding the defaults from the schema. Also, the validation is not returning the actual data and the command needs to be followed by the load_yaml command, which seems silly since `load_yaml` is part of `validate`.

I am probably missing something, but I hope this PR can help address this issue

Note that I had to deactivate the defaults on the plant side as many tests fail. I didn't dig into why that's the case

@kenloen and @kilojoules , please provide your comments