### PR TITLE
use pchip to reconstruct rthick when missing in 1.0 yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,7 +46,8 @@ test = [
     'numpy',
     "pytest",
     "pytest-subtests",
-    "pint"
+    "pint",
+    "scipy"
 ]
 
 [tool.setuptools.packages.find]

--- a/windIO/converters/windIO2windIO.py
+++ b/windIO/converters/windIO2windIO.py
@@ -165,10 +165,10 @@ class v1p0_to_v2p0:
                 for j in range(n_af_available):
                     if blade_os["airfoil_position"]["labels"][i] == dict_v2p0["airfoils"][j]["name"]:
                         rthick_v1p0[i] = dict_v2p0["airfoils"][j]["relative_thickness"]
-            # Use numpy polyfit
-            coeffs = np.polyfit(blade_os["airfoil_position"]["grid"], rthick_v1p0, deg=3)
-            poly = np.poly1d(coeffs)
-            rthick = poly(chord_grid)
+            from scipy.interpolate import PchipInterpolator
+            spline = PchipInterpolator
+            rthick_spline = spline(blade_os["airfoil_position"]["grid"], rthick_v1p0)
+            rthick = rthick_spline(chord_grid)
             rthick[rthick>1.]=1.
             blade_os["rthick"] = {}
             blade_os["rthick"]["grid"] = chord_grid


### PR DESCRIPTION
The relative thickness in windIO 1.0 used to be built with PCHIP. There was confusion around it, as it was not a mandatory field in the yaml, but a 3deg polynomial creates unrealistic distributions, so I'd suggest to shift back to chip, which unfortunately makes spicy a required dependency