### PR TITLE
fix missing build package in publish workflow

### DIFF
--- a/.github/workflows/python-publish.yaml
+++ b/.github/workflows/python-publish.yaml
@@ -20,7 +20,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install setuptools wheel twine
+        pip install build setuptools wheel twine
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}


### PR DESCRIPTION
minor fix to build workflow where between 3.13.3 and 3.13.5 the build package seems to not be installed through the setuptools and wheel packages. now we explicitly add it.

<!--
__ For maintainer use __
Release checklist:
- Update the version in
    - [ ] README.md
    - [ ] setup.py
- [ ] Verify docs builds correctly
- [ ] Create a tag in the IEAWindTask37/windIO repository
-->